### PR TITLE
Avoid shimming ~, { and <-

### DIFF
--- a/R/exported.R
+++ b/R/exported.R
@@ -9,6 +9,7 @@
 #' @param clock whether to time intermediate steps, `FALSE` by default unless you
 #' set `options(boom.clock = TRUE)`. The execution time of a step doesn't include the
 #' execution time of its previously printed sub-steps.
+#' @param ignore Functions to ignore. `::` and `:::` are always ignored.
 #' @param print A function, a formula or a list of functions or formulas.
 #'
 #' @details
@@ -44,7 +45,7 @@
 #'
 #' # rig a function
 #' rig(ave)(warpbreaks$breaks, warpbreaks$wool)
-boom <- function(expr, clock = getOption("boom.clock"), print = getOption("boom.print")) {
+boom <- function(expr, clock = getOption("boom.clock"), print = getOption("boom.print"), ignore = c("~", "{", "(", "<-", "<<-")) {
 
   # if we are in a pipe chain, explode the chain above
   scs <- sys.calls()
@@ -61,7 +62,7 @@ boom <- function(expr, clock = getOption("boom.clock"), print = getOption("boom.
 
   pf   <- parent.frame()
   expr <- substitute(expr)
-  funs <- setdiff(all.names(expr), c(all.vars(expr), "::", ":::"))
+  funs <- setdiff(all.names(expr), c(all.vars(expr), "::", ":::", ignore))
   mask <- list()
   # go through every existing function detected above and create a wrapper
   # in the mask to override it
@@ -90,12 +91,12 @@ boom <- function(expr, clock = getOption("boom.clock"), print = getOption("boom.
 
 #' @export
 #' @rdname boom
-rig <- function(fun, clock = getOption("boom.clock"), print = getOption("boom.print")) {
+rig <- function(fun, clock = getOption("boom.clock"), print = getOption("boom.print"), ignore = c("~", "{", "(", "<-", "<<-")) {
   expr <- body(fun)
   reset_globals()
   pf   <- parent.frame()
   funs <- setdiff(all.names(expr), c(
-    all.vars(expr), "::", ":::", "~", "{", "<-"))
+    all.vars(expr), "::", ":::", ignore))
   mask <- new.env(parent = environment(fun))
   # go through every existing function detected above and create a wrapper
   # in the mask to override it

--- a/R/exported.R
+++ b/R/exported.R
@@ -95,7 +95,7 @@ rig <- function(fun, clock = getOption("boom.clock"), print = getOption("boom.pr
   reset_globals()
   pf   <- parent.frame()
   funs <- setdiff(all.names(expr), c(
-    all.vars(expr), "::", ":::"))
+    all.vars(expr), "::", ":::", "~", "{", "<-"))
   mask <- new.env(parent = environment(fun))
   # go through every existing function detected above and create a wrapper
   # in the mask to override it

--- a/man/boom.Rd
+++ b/man/boom.Rd
@@ -5,9 +5,19 @@
 \alias{rig}
 \title{Print the Output of Intermediate Steps of a Call}
 \usage{
-boom(expr, clock = getOption("boom.clock"), print = getOption("boom.print"))
+boom(
+  expr,
+  clock = getOption("boom.clock"),
+  print = getOption("boom.print"),
+  ignore = c("~", "{", "(", "<-", "<<-")
+)
 
-rig(fun, clock = getOption("boom.clock"), print = getOption("boom.print"))
+rig(
+  fun,
+  clock = getOption("boom.clock"),
+  print = getOption("boom.print"),
+  ignore = c("~", "{", "(", "<-", "<<-")
+)
 }
 \arguments{
 \item{expr}{call to explode}
@@ -17,6 +27,8 @@ set \code{options(boom.clock = TRUE)}. The execution time of a step doesn't incl
 execution time of its previously printed sub-steps.}
 
 \item{print}{A function, a formula or a list of functions or formulas.}
+
+\item{ignore}{Functions to ignore. \code{::} and \code{:::} are always ignored.}
 
 \item{fun}{function ro \code{rig()}}
 }


### PR DESCRIPTION
These only add noise to the output. 

I also think we never want to go inside `~`. Do we need to avoid `"function"` too, for similar reasons?

Closes #12.