### PR TITLE
WIP: Show message/warning if a function is missing during rigging/booming

### DIFF
--- a/R/exported.R
+++ b/R/exported.R
@@ -77,7 +77,10 @@ boom <- function(
   for (fun_chr in funs) {
     # `funs` will include namespaces and functions yet to be defined (in the case of a script)
     # so we don't want to fail here if the object doesn't exist
-    if(!exists(fun_chr, pf)) next
+    if(!exists(fun_chr, pf)) {
+      message("Not booming undefined `", fun_chr, "()`.")
+      next
+    }
 
     # fetch the env, primitives don't have one, but they're in the base package
     fun_val <- get(fun_chr, envir = pf)
@@ -117,7 +120,10 @@ rig <- function(
   for (fun_chr in funs) {
     # fun will include namespaces nad functions yet to be defined (in the case of a script)
     # so we don't want to fail here if the object doesn't exist
-    if(!exists(fun_chr, rigged_fun_env)) next
+    if(!exists(fun_chr, rigged_fun_env)) {
+      message("Not rigging undefined `", fun_chr, "()`.")
+      next
+    }
 
     # fetch the env, primitives don't have one, but they're in the base package
     fun_val <- get(fun_chr, envir = rigged_fun_env)

--- a/tests/testthat/_snaps/boom.md
+++ b/tests/testthat/_snaps/boom.md
@@ -26,7 +26,6 @@
       fun <- (function(x) {
         x
       })
-    Code
       boomer::boom(fun(1:3))
     Output
       1:3
@@ -57,17 +56,6 @@
       subset(head(mtcars, 2), qsec > 17)
                     mpg cyl disp  hp drat    wt  qsec vs am gear carb
       Mazda RX4 Wag  21   6  160 110  3.9 2.875 17.02  0  1    4    4
-    Code
-      library(magrittr, quietly = TRUE, verbose = FALSE)
-    Warning <simpleWarning>
-      package 'magrittr' was built under R version 4.0.4
-    Message <packageStartupMessage>
-      
-      Attaching package: 'magrittr'
-    Message <packageStartupMessage>
-      The following objects are masked from 'package:testthat':
-      
-          equals, is_less_than, not
     Code
       mtcars %>% head(2) %>% subset(qsec > 17) %>% boom()
     Output

--- a/tests/testthat/_snaps/rig.md
+++ b/tests/testthat/_snaps/rig.md
@@ -5,9 +5,7 @@
         n <- 1 + 2 * 3
         sum(base::nchar(utils:::head(x, -n)))
       })
-    Code
       rigged <- rig(fun)
-    Code
       rigged(letters)
     Output
       2 * 3
@@ -22,6 +20,5 @@
        [1] 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
       sum(base::nchar(utils:::head(x, -n)))
       [1] 19
-    Output
       [1] 19
 

--- a/tests/testthat/test-boom.R
+++ b/tests/testthat/test-boom.R
@@ -15,10 +15,12 @@ test_that("boom() works with a global function", {
 })
 
 test_that("boom() works with README examples", {
+  library(magrittr, quietly = TRUE, verbose = FALSE)
+
   expect_snapshot({
     boom(1 + !1 * 2)
     boom(subset(head(mtcars, 2), qsec > 17))
-    library(magrittr, quietly = TRUE, verbose = FALSE)
+
     mtcars %>%
       head(2) %>%
       subset(qsec > 17) %>%


### PR DESCRIPTION
Includes #18. Requires #19, otherwise tests fail.