### PR TITLE
boomer.ignore.inside

### DIFF
--- a/R/boomer-package.R
+++ b/R/boomer-package.R
@@ -27,9 +27,12 @@
 #'   and their values when they are evaluated. Defaults to `TRUE`.
 #' - `boomer.visible_only`: Whether to hide the output of functions which return
 #'   invisibly. Defaults to `FALSE`.
-#' - `boomer.ignore`: Vector of functions for which we don't want the result
+#' - `boomer.ignore`: Vector of function names for which we don't want the result
 #'   printed (usually because it's redundant). Defaults to
-#'   `c("~", "{", "(", "<-", "<<-", "=")`
+#'   `c("~", "{", "(", "<-", "<<-", "=")`.
+#' - `boomer.ignore.inside`: list of functions (values, not names) for which we
+#'   don't want the arguments boomed, this might be useful when calling a
+#'   function that loops too many times.
 #' - `boomer.safe_print`: Whether to replace emoticons by characters compatible
 #'   with all systems. This is useful for reprexes (see \pkg{reprex} package) and
 #'   for knitted report in case the output of those doesn't look good on your system.

--- a/man/boomer-package.Rd
+++ b/man/boomer-package.Rd
@@ -3,6 +3,7 @@
 \docType{package}
 \name{boomer-package}
 \alias{boomer-package}
+\alias{_PACKAGE}
 \alias{boomer}
 \title{boomer: Debugging Tools to Inspect the Intermediate Steps of a Call}
 \description{
@@ -37,9 +38,12 @@ replace it at run time. Defaults to \code{FALSE}.
 and their values when they are evaluated. Defaults to \code{TRUE}.
 \item \code{boomer.visible_only}: Whether to hide the output of functions which return
 invisibly. Defaults to \code{FALSE}.
-\item \code{boomer.ignore}: Vector of functions for which we don't want the result
+\item \code{boomer.ignore}: Vector of function names for which we don't want the result
 printed (usually because it's redundant). Defaults to
-\code{c("~", "{", "(", "<-", "<<-", "=")}
+\code{c("~", "{", "(", "<-", "<<-", "=")}.
+\item \code{boomer.ignore.inside}: list of functions (values, not names) for which we
+don't want the arguments boomed, this might be useful when calling a
+function that loops too many times.
 \item \code{boomer.safe_print}: Whether to replace emoticons by characters compatible
 with all systems. This is useful for reprexes (see \pkg{reprex} package) and
 for knitted report in case the output of those doesn't look good on your system.

--- a/man/boomer-package.Rd
+++ b/man/boomer-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{boomer-package}
 \alias{boomer-package}
-\alias{_PACKAGE}
 \alias{boomer}
 \title{boomer: Debugging Tools to Inspect the Intermediate Steps of a Call}
 \description{

--- a/tests/testthat/_snaps/ignore.inside.md
+++ b/tests/testthat/_snaps/ignore.inside.md
@@ -1,0 +1,71 @@
+# boom.ignore.inside
+
+    Code
+      options(boomer.ignore.inside = NULL)
+      data.frame(a = 1:3) %>% transform(b = a + 1) %>% boom()
+    Output
+      <  data.frame(a = 1:3) %>% transform(b = a + 1) 
+      . <  transform(., b = a + 1) 
+      . . <  data.frame(a = 1:3) 
+      . . . <  >  1:3 
+      . . . [1] 1 2 3
+      . . . 
+      . . >  data.frame(a = 1:3) 
+      . .   a
+      . . 1 1
+      . . 2 2
+      . . 3 3
+      . . 
+      . . <  >  a + 1 
+      . . [1] 2 3 4
+      . . 
+      . >  transform(., b = a + 1) 
+      .   a b
+      . 1 1 2
+      . 2 2 3
+      . 3 3 4
+      . 
+      >  data.frame(a = 1:3) %>% transform(b = a + 1) 
+        a b
+      1 1 2
+      2 2 3
+      3 3 4
+      
+        a b
+      1 1 2
+      2 2 3
+      3 3 4
+    Code
+      options(boomer.ignore.inside = list(transform))
+      data.frame(a = 1:3) %>% transform(b = a + 1) %>% boom()
+    Output
+      <  data.frame(a = 1:3) %>% transform(b = a + 1) 
+      . . <  data.frame(a = 1:3) 
+      . . . <  >  1:3 
+      . . . [1] 1 2 3
+      . . . 
+      . . >  data.frame(a = 1:3) 
+      . .   a
+      . . 1 1
+      . . 2 2
+      . . 3 3
+      . . 
+      . <  >  transform(., b = a + 1) 
+      .   a b
+      . 1 1 2
+      . 2 2 3
+      . 3 3 4
+      . 
+      >  data.frame(a = 1:3) %>% transform(b = a + 1) 
+        a b
+      1 1 2
+      2 2 3
+      3 3 4
+      
+        a b
+      1 1 2
+      2 2 3
+      3 3 4
+    Code
+      options(boomer.ignore.inside = NULL)
+

--- a/tests/testthat/test-ignore.inside.R
+++ b/tests/testthat/test-ignore.inside.R
@@ -1,0 +1,13 @@
+test_that("boom.ignore.inside", {
+  expect_snapshot({
+    options("boomer.ignore.inside" = NULL)
+    data.frame(a = 1:3) %>%
+      transform( b = a + 1) %>%
+      boom()
+    options("boomer.ignore.inside" = list(transform))
+    data.frame(a = 1:3) %>%
+      transform( b = a + 1) %>%
+      boom()
+    options("boomer.ignore.inside" = NULL)
+  })
+})


### PR DESCRIPTION
Closes #93 

@krlmlr how does it look ? Note the difference between the magrittr and base pipe here.

It is possible in principle to boom only selected arguments, by manipulating the promise evaluation environment with rlang magic, but then I'm not sure what would the API look like.

``` r
library(dplyr, w = F)
library(boomer)

options("boomer.ignore.inside" = list(dplyr::mutate))

tibble(a = 1:3) |>
  mutate(.by = a, b = a + 1) |>
  identity() |>
  boom()
#> 💣 identity(mutate(tibble(a = 1:3), .by = a, b = a + 1)) 
#> · 💣 💥 mutate(tibble(a = 1:3), .by = a, b = a + 1) 
#> · # A tibble: 3 × 2
#> ·       a     b
#> ·   <int> <dbl>
#> · 1     1     2
#> · 2     2     3
#> · 3     3     4
#> · 
#> 💥 identity(mutate(tibble(a = 1:3), .by = a, b = a + 1)) 
#> # A tibble: 3 × 2
#>       a     b
#>   <int> <dbl>
#> 1     1     2
#> 2     2     3
#> 3     3     4
#> # A tibble: 3 × 2
#>       a     b
#>   <int> <dbl>
#> 1     1     2
#> 2     2     3
#> 3     3     4

tibble(a = 1:3) %>%
  mutate(.by = a, b = a + 1) %>%
  identity() %>%
  boom()
#> 💣 tibble(a = 1:3) %>%... 
#> · 💣 identity(.) 
#> · · · 💣 tibble(a = 1:3) 
#> · · · · 💣 💥 1:3 
#> · · · · [1] 1 2 3
#> · · · · 
#> · · · 💥 tibble(a = 1:3) 
#> · · · # A tibble: 3 × 1
#> · · ·       a
#> · · ·   <int>
#> · · · 1     1
#> · · · 2     2
#> · · · 3     3
#> · · · 
#> · · 💣 💥 mutate(., .by = a, b = a + 1) 
#> · · # A tibble: 3 × 2
#> · ·       a     b
#> · ·   <int> <dbl>
#> · · 1     1     2
#> · · 2     2     3
#> · · 3     3     4
#> · · 
#> · 💥 identity(.) 
#> · # A tibble: 3 × 2
#> ·       a     b
#> ·   <int> <dbl>
#> · 1     1     2
#> · 2     2     3
#> · 3     3     4
#> · 
#> 💥 tibble(a = 1:3) %>%
#>      mutate(.by = a, b = a + 1) %>%
#>      identity() 
#> # A tibble: 3 × 2
#>       a     b
#>   <int> <dbl>
#> 1     1     2
#> 2     2     3
#> 3     3     4
#> # A tibble: 3 × 2
#>       a     b
#>   <int> <dbl>
#> 1     1     2
#> 2     2     3
#> 3     3     4
```

<sup>Created on 2024-01-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>