### PR TITLE
Use a stable error in the failing-pipe test

### DIFF
--- a/tests/testthat/_snaps/boom.md
+++ b/tests/testthat/_snaps/boom.md
@@ -252,20 +252,30 @@
       
       [1] 1
     Code
-      1 %>% identity() %>% missing_function() %>% I() %>% boomer::boom()
+      add_string <- (function(x) {
+        x + "a"
+      })
+      1 %>% identity() %>% add_string() %>% I() %>% boomer::boom()
     Output
       <  1 %>%... 
       . <  I(.) 
+      . . <  add_string(.) 
+      . . . <  identity(.) 
+      . . . >  identity(.) 
+      . . . [1] 1
+      . . . 
+      . . >  add_string(.) 
+      Error: simpleError/error/condition
       . >  I(.) 
       Error: simpleError/error/condition
       >  1 %>%
            identity() %>%
-           missing_function() %>%
+           add_string() %>%
            I() 
       Error: simpleError/error/condition
     Condition
-      Error in `missing_function()`:
-      ! could not find function "missing_function"
+      Error in `x + "a"`:
+      ! non-numeric argument to binary operator
     Code
       eagerly_failing_function <- (function(x) {
         stop("oops")

--- a/tests/testthat/test-boom.R
+++ b/tests/testthat/test-boom.R
@@ -88,9 +88,13 @@ test_that("can debug failing pipes (#17)", {
       I() %>%
       boomer::boom()
 
+    add_string <- function(x) {
+      x + "a"
+    }
+
     1 %>%
       identity() %>%
-      missing_function() %>%
+      add_string() %>%
       I() %>%
       boomer::boom()
 


### PR DESCRIPTION
The "can debug failing pipes" snapshot relied on a "could not find function" error, whose condition class hierarchy changed in r-devel (simpleError -> functionNotFoundError/objectNotFoundError), making the snapshot churn across R versions.

Replace the missing-function pipe with one that does arithmetic on a string ("non-numeric argument to binary operator"), a plain simpleError that is stable across R versions.